### PR TITLE
cache connection and response objects for the life of the entire example

### DIFF
--- a/tests/spec/support/examples/connection.rb
+++ b/tests/spec/support/examples/connection.rb
@@ -2,7 +2,7 @@
 
 # Examples for all adapter accessing the given base url
 shared_examples 'a connection making requests' do |base_url, adapter|
-  let(:conn) do
+  before :all do
     conn_options = {
       headers: {
         'X-Faraday-Live' => '1',
@@ -10,7 +10,7 @@ shared_examples 'a connection making requests' do |base_url, adapter|
       },
     }
 
-    Faraday.new("#{base_url}/requests", conn_options) do |conn|
+    @conn = Faraday.new("#{base_url}/requests", conn_options) do |conn|
       conn.request :url_encoded
       conn.adapter(adapter.key)
     end
@@ -40,8 +40,8 @@ shared_examples 'a connection making requests' do |base_url, adapter|
   end if FaradayMethods.get_method?(adapter)
 
   describe "with #{adapter}: #HEAD" do
-    let(:response) do
-      conn.head('test')
+    before :all do
+      @response = conn.head('test')
     end
 
     include_examples 'any request', :head

--- a/tests/spec/support/examples/request_idempotent.rb
+++ b/tests/spec/support/examples/request_idempotent.rb
@@ -2,8 +2,8 @@
 
 # runs tests for an adapter and http method with no request body
 shared_examples 'an idempotent request' do |http_method, adapter|
-  let(:response) do
-    conn.public_send(http_method, 'test')
+  before :all do
+    @response = conn.public_send(http_method, 'test')
   end
 
   include_examples 'any request', http_method

--- a/tests/spec/support/examples/request_json.rb
+++ b/tests/spec/support/examples/request_json.rb
@@ -2,8 +2,8 @@
 
 # Examples for an adapter and http method with a json request body
 shared_examples 'a json request' do |http_method, adapter|
-  let(:response) do
-    conn.public_send(http_method, 'test') do |req|
+  before :all do
+    @response = conn.public_send(http_method, 'test') do |req|
       req.headers[:content_type] = 'application/json'
       req.body = {request_param: ['faraday live']}.to_json
     end

--- a/tests/spec/support/examples/request_post.rb
+++ b/tests/spec/support/examples/request_post.rb
@@ -2,8 +2,8 @@
 
 # Examples for an adapter and http method with a form request body
 shared_examples 'a form post request' do |http_method, adapter|
-  let(:response) do
-    conn.public_send(http_method, 'test') do |req|
+  before :all do
+    @response = conn.public_send(http_method, 'test') do |req|
       req.body = {request_param: 'faraday live'}
     end
   end

--- a/tests/spec/support/helpers.rb
+++ b/tests/spec/support/helpers.rb
@@ -6,4 +6,12 @@ module FaradayHelpers
   def sha256(s)
     Digest::SHA256.hexdigest(s.to_s)
   end
+
+  def response
+    @response
+  end
+
+  def conn
+    @conn
+  end
 end


### PR DESCRIPTION
This greatly reduces HTTP traffic by ensuring only unique HTTP calls are made.

CMD: `$ TEST_PROTO=https docker-compose run tests`

## BEFORE

* Finished in 12.96 seconds (files took 0.67743 seconds to load)
* 732 examples, 0 failures
* 732 http requests from server logs

## AFTER

* Finished in 2.07 seconds (files took 0.81795 seconds to load)
* 732 examples, 0 failures
* 83 http requests from server logs
