### PR TITLE
Test streaming

### DIFF
--- a/server/slowwriter.go
+++ b/server/slowwriter.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"net/http"
+	"time"
+)
+
+func Slowdown(w http.ResponseWriter, size int, delay time.Duration) http.ResponseWriter {
+	return &slow{
+		ResponseWriter: w,
+		chunksize:      size,
+		delay:          delay,
+	}
+}
+
+type slow struct {
+	http.ResponseWriter
+	chunksize int
+	delay     time.Duration
+}
+
+func (s *slow) Write(p []byte) (int, error) {
+	pos := 0
+	plen := len(p)
+	for {
+		if rem := plen - pos; s.chunksize >= rem {
+			n, err := s.ResponseWriter.Write(p[pos : pos+rem])
+			return pos + n, err
+		}
+
+		n, err := s.ResponseWriter.Write(p[pos : pos+s.chunksize])
+		pos += n
+		if err != nil {
+			return pos, err
+		}
+
+		if f, ok := s.ResponseWriter.(http.Flusher); ok {
+			f.Flush()
+		}
+
+		time.Sleep(s.delay)
+	}
+}

--- a/tests/spec/support/adapters.rb
+++ b/tests/spec/support/adapters.rb
@@ -53,6 +53,7 @@ class FaradayAdapters
       :unverified_https_bug, # https://github.com/technoweenie/faraday-live/issues/4
       :https_proxy_bug, # https://github.com/technoweenie/faraday-live/issues/6
       :socks_proxy,
+      :stream_response,
     ].each do |feature|
       define_method("#{feature}?") { @features.include?(feature) }
     end
@@ -82,7 +83,7 @@ class FaradayAdapters
       :trace_method, :connect_with_response_body),
 
     :net_http => Adapter.new(:net_http,
-      :socks_proxy, :trace_method, :connect_with_response_body),
+      :socks_proxy, :trace_method, :connect_with_response_body, :stream_response),
 
     :patron => Adapter.new(:patron,
       :unverified_https_bug),

--- a/tests/spec/support/examples/common.rb
+++ b/tests/spec/support/examples/common.rb
@@ -7,6 +7,13 @@ shared_examples 'common request tests' do |url_kind, adapter, options|
     it_behaves_like 'an idempotent request', :get, url_kind, adapter,
       request_header: options[:request_header],
       response_header: options[:response_header]
+
+    if adapter.stream_response?
+      it_behaves_like 'a streaming request', url_kind, adapter,
+        proxy: options[:proxy],
+        request_header: options[:request_header],
+        response_header: options[:response_header]
+    end
   end if FaradayMethods.get_method?(adapter)
 
   context "(#{adapter}) #POST request" do

--- a/tests/spec/support/examples/common.rb
+++ b/tests/spec/support/examples/common.rb
@@ -9,7 +9,7 @@ shared_examples 'common request tests' do |url_kind, adapter, options|
       response_header: options[:response_header]
 
     if adapter.stream_response?
-      it_behaves_like 'a streaming request', url_kind, adapter,
+      it_behaves_like 'a request with a streaming body', url_kind, adapter,
         proxy: options[:proxy],
         request_header: options[:request_header],
         response_header: options[:response_header]

--- a/tests/spec/support/examples/proxy.rb
+++ b/tests/spec/support/examples/proxy.rb
@@ -37,5 +37,6 @@ shared_examples 'a proxied connection' do |adapter, options|
     },
     request_header: {
       'Faraday-Proxy' => expected,
-    }
+    },
+    proxy: options[:proxy]
 end

--- a/tests/spec/support/examples/request_streaming.rb
+++ b/tests/spec/support/examples/request_streaming.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# Examples for an adapter streaming a response body
+shared_examples 'a streaming request' do |url_kind, adapter, options|
+  options ||= {}
+
+  before :all do
+    @data = []
+    @sizes = []
+    @response = conn.get('streaming', nil, options[:request_header]) do |req|
+      req.params["delay"] = 1
+      req.params["size"] = 200
+      req.options.on_data = Proc.new do |chunk, size|
+        #puts " * * * RECV #{size.inspect} * * *"
+        #puts chunk
+        #puts " * * * END RECV * * *"
+        @data << chunk
+        @sizes << size
+      end
+    end
+
+    if @data.size > 0
+      expect { @body = JSON.parse(@data.join) }.not_to raise_error
+    end
+  end
+
+  include_examples 'any request', :get, {
+    url_kind: url_kind,
+    response_header: options[:response_header],
+  }
+
+  it 'receives empty response body' do
+    expect(@response.body).to eq("")
+  end
+
+  it 'receives body/size chunks' do
+    expect(@sizes.size).to eq(@data.size)
+
+    case options[:proxy]
+    when :https_auth_proxy, :https_proxy
+      # test https proxy doesn't flush chunked response writes
+      expect(@sizes.size).to eq(1)
+    when :http_auth_proxy, :http_proxy
+      if url_kind == :https
+        expect(@sizes.size).to be > 1
+      else
+        # test https proxy doesn't flush chunked response writes
+        expect(@sizes.size).to eq(1)
+      end
+    else
+      expect(@sizes.size).to be > 1
+    end
+  end
+
+  it 'receives increasing body sizes' do
+    @sizes.inject(0) do |prev, num|
+      expect(prev).to be < num
+      num
+    end
+  end
+
+  # From shared matcher:
+  # "any request expecting a response body"
+  # Can't use it here because streaming requests set no content-length
+  it 'uses valid method' do
+    expect(body['Method']).to eq("GET")
+  end
+
+  it 'accesses correct host' do
+    expect(body['Host']).to eq(ENV['HTTP_HOST'])
+  end
+
+  it 'crafts correct request uri' do
+    expect(body['RequestURI']).to eq('/requests/streaming?delay=1&size=200')
+  end
+end

--- a/tests/spec/support/examples/request_streaming.rb
+++ b/tests/spec/support/examples/request_streaming.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Examples for an adapter streaming a response body
-shared_examples 'a streaming request' do |url_kind, adapter, options|
+shared_examples 'a request with a streaming body' do |url_kind, adapter, options|
   options ||= {}
 
   before :all do


### PR DESCRIPTION
This adds two things: 

1. The server can be told to write the response body in chunks, and then flush and sleep between writes. Any test request with `?delay=1&size=50` will write 50 bytes at a time, sleeping 1s between writes and flushes.
2. Adapters that support the `stream_response` feature will now make a slow request, asserting the number of chunks returned, and other details of how Faraday response body streaming works.

Some things I learned about Faraday:
* Only `net_http` supports streaming currently. Not even `net_http_persistent`!
* Some of the adapters pretend to support it, but give a warning.